### PR TITLE
Medida para que o rain sempre ocupe a tela inteira

### DIFF
--- a/public/rain.js
+++ b/public/rain.js
@@ -11,6 +11,10 @@ window.addEventListener("keydown", function (event) {
   }
 });
 
+window.addEventListener("resize", function () {
+  mousePressed()
+});
+
 function setup() {
   noStroke();
   colorMode(HSB, 360, 100, 1, 0.1);


### PR DESCRIPTION
## Problema

Ao redimensionar a tela do navegador ou usar o devtools, o rain - que são os caracteres que vão descendo na tela estilo matrix - não ocupa a tela inteira, ou melhor, não é responsivo a tela do dispositivo.

## Solução

Ao redimensionar a tela, chamar a função mousePressed que vai meio que recarregar o rain, redimensionando ela a tela, assim deixando responsivo.

> Obs.: Eu demorei pra fazer esse pull request, por um medo meu. Pois não sei muito bem como funciona por debaixo dos panos. Eu descobri esse repo pelo curso.dev.